### PR TITLE
Adding support for other cases

### DIFF
--- a/lib/handlers/string.js
+++ b/lib/handlers/string.js
@@ -10,59 +10,59 @@ var StringTypeHandler = function(opts) {
 
     var onion = new Onion('string');
 
-    var Email = function(msg, tests, next, exit) {
-        var test = _.find(tests, {
+    var Email = function(msg, schema, next, exit) {
+        var test = _.find(schema._tests, {
             name: 'email'
         });
         if (test) {
             debug('generating an email');
             return exit(null, chance.email());
         }
-        return next(null, msg, tests);
+        return next(null, msg, schema);
     };
 
-    var Guid = function(msg, tests, next, exit) {
-        var test = _.find(tests, {
+    var Guid = function(msg, schema, next, exit) {
+        var test = _.find(schema._tests, {
             name: 'guid'
         });
         if (test) {
             debug('generating a guid');
             return exit(null, uuid.v4());
         }
-        return next(null, msg, tests);
+        return next(null, msg, schema);
     };
 
-    var Ip = function(msg, tests, next, exit) {
-        var test = _.find(tests, {
+    var Ip = function(msg, schema, next, exit) {
+        var test = _.find(schema._tests, {
             name: 'ip'
         });
         if (test) {
             debug('generating an ip');
             return exit(null, chance.ip());
         }
-        return next(null, msg, tests);
+        return next(null, msg, schema);
     };
 
-    var Hostname = function(msg, tests, next, exit) {
-        var test = _.find(tests, {
+    var Hostname = function(msg, schema, next, exit) {
+        var test = _.find(schema._tests, {
             name: 'hostname'
         });
         if (test) {
             debug('generating a hostname');
             return exit(null, chance.domain());
         }
-        return next(null, msg, tests);
+        return next(null, msg, schema);
     };
 
-    var MinLength = function(msg, tests, next) {
-        var min = _.find(tests, {
+    var MinLength = function(msg, schema, next) {
+        var min = _.find(schema._tests, {
             name: 'min'
         });
         if (min) {
             min = min.arg;
             if (msg.length >= min) {
                 // Message is OK as it is
-                return next(null, msg, tests);
+                return next(null, msg, schema);
             }
 
             msg = chance.sentence({
@@ -76,26 +76,26 @@ var StringTypeHandler = function(opts) {
             debug('generating a string of ' + goTo + ' characters');
             msg = msg.substr(0, goTo);
         }
-        next(null, msg, tests);
+        next(null, msg, schema);
     };
 
-    var MaxLength = function(msg, tests, next) {
+    var MaxLength = function(msg, schema, next) {
         /* jshint maxcomplexity: 6 */
-        var max = _.find(tests, {
+        var max = _.find(schema._tests, {
             name: 'max'
         });
         if (max) {
             max = max.arg;
             if (msg.length <= max) {
                 // Message is OK as it is
-                return next(null, msg, tests);
+                return next(null, msg, schema);
             }
 
             msg = chance.sentence({
                 words: max
             });
 
-            var min = _.find(tests, {
+            var min = _.find(schema._tests, {
                 name: 'min'
             });
             if (min) {
@@ -110,11 +110,11 @@ var StringTypeHandler = function(opts) {
             debug('generating a string between ' + min + ' and ' + max + ' characters');
             msg = msg.substr(0, goTo);
         }
-        return next(null, msg, tests);
+        return next(null, msg, schema);
     };
 
-    var RegEx = function(msg, tests, next) {
-        var regex = _.find(tests, {
+    var RegEx = function(msg, schema, next) {
+        var regex = _.find(schema._tests, {
             name: 'regex'
         });
         if (regex) {
@@ -122,7 +122,7 @@ var StringTypeHandler = function(opts) {
             debug('generating a regex');
             msg = new RandExp(regex).gen();
         }
-        next(null, msg, tests);
+        next(null, msg, schema);
     };
 
     onion.add(Guid, 'guid');
@@ -137,7 +137,7 @@ var StringTypeHandler = function(opts) {
         handle: function(schema, callback) {
             // Start with a random string
             var msg = chance.sentence();
-            onion.handle(msg, schema._tests, function(err, output) {
+            onion.handle(msg, schema, function(err, output) {
                 debug('output', output);
                 callback(err, output);
             });

--- a/lib/handlers/string.js
+++ b/lib/handlers/string.js
@@ -125,6 +125,14 @@ var StringTypeHandler = function(opts) {
         next(null, msg, schema);
     };
 
+    var AllowedOptions = function (msg, schema, next) {
+        var options = schema._valids._set;
+        if (options.length > 0) {
+            msg = options[Math.floor(Math.random() * options.length)];
+        }
+        next(null, msg, schema);
+    };
+    
     var UpperCase = function (msg, schema, next) {
         var uppercase = _.find(schema._tests, {
             name: 'uppercase'
@@ -152,6 +160,7 @@ var StringTypeHandler = function(opts) {
     onion.add(MinLength, 'min-length');
     onion.add(MaxLength, 'max-length');
     onion.add(RegEx, 'regex');
+    onion.add(AllowedOptions, 'allowed-options');
     onion.add(UpperCase, 'uppercase');
     onion.add(LowerCase, 'lowercase');
 

--- a/lib/handlers/string.js
+++ b/lib/handlers/string.js
@@ -126,11 +126,10 @@ var StringTypeHandler = function(opts) {
     };
 
     var UpperCase = function (msg, schema, next) {
-        var lowercase = _.find(schema._tests, {
+        var uppercase = _.find(schema._tests, {
             name: 'uppercase'
         });
-        if (lowercase && schema._settings !== null &&
-            schema._settings.convert === false) {
+        if (uppercase) {
             msg = msg.toUpperCase();
         }
         next(null, msg, schema);
@@ -140,8 +139,7 @@ var StringTypeHandler = function(opts) {
         var lowercase = _.find(schema._tests, {
             name: 'lowercase'
         });
-        if (lowercase && schema._settings !== null &&
-            schema._settings.convert === false) {
+        if (lowercase) {
             msg = msg.toLowerCase();
         }
         next(null, msg, schema);

--- a/lib/handlers/string.js
+++ b/lib/handlers/string.js
@@ -125,6 +125,17 @@ var StringTypeHandler = function(opts) {
         next(null, msg, schema);
     };
 
+    var UpperCase = function (msg, schema, next) {
+        var lowercase = _.find(schema._tests, {
+            name: 'uppercase'
+        });
+        if (lowercase && schema._settings !== null &&
+            schema._settings.convert === false) {
+            msg = msg.toUpperCase();
+        }
+        next(null, msg, schema);
+    };
+
     onion.add(Guid, 'guid');
     onion.add(Email, 'email');
     onion.add(Ip, 'ip');
@@ -132,6 +143,7 @@ var StringTypeHandler = function(opts) {
     onion.add(MinLength, 'min-length');
     onion.add(MaxLength, 'max-length');
     onion.add(RegEx, 'regex');
+    onion.add(UpperCase, 'uppercase');
 
     return {
         handle: function(schema, callback) {

--- a/lib/handlers/string.js
+++ b/lib/handlers/string.js
@@ -136,6 +136,17 @@ var StringTypeHandler = function(opts) {
         next(null, msg, schema);
     };
 
+    var LowerCase = function (msg, schema, next) {
+        var lowercase = _.find(schema._tests, {
+            name: 'lowercase'
+        });
+        if (lowercase && schema._settings !== null &&
+            schema._settings.convert === false) {
+            msg = msg.toLowerCase();
+        }
+        next(null, msg, schema);
+    };
+
     onion.add(Guid, 'guid');
     onion.add(Email, 'email');
     onion.add(Ip, 'ip');
@@ -144,6 +155,7 @@ var StringTypeHandler = function(opts) {
     onion.add(MaxLength, 'max-length');
     onion.add(RegEx, 'regex');
     onion.add(UpperCase, 'uppercase');
+    onion.add(LowerCase, 'lowercase');
 
     return {
         handle: function(schema, callback) {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lib-onion": "^0.1.1",
     "lodash": "^3.9.3",
     "moment": "^2.10.6",
-    "randexp": "^0.4.2",
+    "randexp": "0.4.6",
     "uuid": "^3.0.0"
   },
   "contributors": [

--- a/test/string.js
+++ b/test/string.js
@@ -84,9 +84,16 @@ describe('String', function() {
         go(schema, done);
     });
 
-    it('should be able to generate an lowercase string', function(done) {
+    it('should be able to generate a lowercase string', function(done) {
         var schema = Joi.object({
             name: Joi.string().lowercase().options({ convert: false })
+        });
+        go(schema, done);
+    });
+    
+    it('should be able to generate an string from allowed options', function(done) {
+        var schema = Joi.object({
+            choice: Joi.string().valid('first', 'second', 'third')
         });
         go(schema, done);
     });

--- a/test/string.js
+++ b/test/string.js
@@ -76,4 +76,11 @@ describe('String', function() {
         });
         go(schema, done);
     });
+    
+    it('should be able to generate an uppercase string', function(done) {
+        var schema = Joi.object({
+            name: Joi.string().uppercase().options({ convert: false })
+        });
+        go(schema, done);
+    });
 });

--- a/test/string.js
+++ b/test/string.js
@@ -83,4 +83,11 @@ describe('String', function() {
         });
         go(schema, done);
     });
+
+    it('should be able to generate an lowercase string', function(done) {
+        var schema = Joi.object({
+            name: Joi.string().lowercase().options({ convert: false })
+        });
+        go(schema, done);
+    });
 });


### PR DESCRIPTION
Following cases are now supported:

- Uppercase string, i.e. `Joi.string().uppercase()`
- Lowercase string, i.e. `Joi.string().lowercase()`
- Valid string options, i.e. `Joi.string().valid('first', 'second', 'third')`
