### PR TITLE
Optional callback, promise support

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -45,14 +45,26 @@ var typeFactory = new TypeFactory();
 
 var Generator = function() {
     var generate = function(schema, callback) {
-        typeFactory.gimme(schema, function(err, tf) {
-            if (err) {
-                return callback(err, null);
-            }
-            tf.handle(schema, function(err, val) {
-                callback(err, val);
+        var promise = new Promise(function(resolve, reject) {
+            typeFactory.gimme(schema, function(err, tf) {
+                if (err) {
+                    reject(err);
+                } else {
+                    tf.handle(schema, function (err, val) {
+                        if (err) {
+                            reject(err);
+                        }
+                        resolve(val);
+                    });
+                }
             });
         });
+
+        if (callback && typeof callback === 'function') {
+            promise.then(callback.bind(null, null), callback);
+        }
+
+        return promise;
     };
     return Object.freeze(generate);
 };


### PR DESCRIPTION
This PR makes the callback optional, returning a promise if no callback is supplied. This change is backwards compatible. The plugin can now be used as follows:

```javascript
var Joi = require('joi');
var generate = new require('joi-generate').Generate();

var schema = Joi.object({
	details: Joi.string().min(100).max(200)
});

generate(schema).then(function(model) {
	/*
	 * model = { details: 'some random string between 100 and 200 chars' }
	 */
})
.catch(err) {
	// error treatment
};
```